### PR TITLE
Migrate to OL8 base image and use --pull=never to allow overriding of base image

### DIFF
--- a/Dockerfile.oracle.ol8
+++ b/Dockerfile.oracle.ol8
@@ -11,11 +11,11 @@ RUN dnf install -y net-tools ${RPM} && \
 ADD dist/mk-docker-opts.sh /opt/bin
 RUN test -d /LICENSES || ln -s /usr/share/licenses /LICENSES
 
-FROM container-registry.oracle.com/os/oraclelinux:8-slim
+FROM container-registry.oracle.com/os/oraclelinux:8
 
-RUN microdnf install -y iproute iptables ca-certificates && \
+RUN dnf install -y iproute iptables ca-certificates && \
     update-ca-trust && \
-    microdnf clean all && \
+    dnf clean all && \
     rm -rf /var/cache && \
     mkdir -p /opt/bin
 

--- a/buildrpm/flannel-container-image.spec
+++ b/buildrpm/flannel-container-image.spec
@@ -36,9 +36,9 @@ docker info
 yum clean all && yumdownloader --destdir=$(pwd) %{rpm_name}
 
 %if %{?oraclelinux} == 8
-docker build --pull --build-arg RPM=%{rpm_name}.rpm --build-arg https_proxy=${https_proxy} -t %{docker_tag} -f %{dockerfile} .
+docker build --pull=never --squash --build-arg RPM=%{rpm_name}.rpm --build-arg https_proxy=${https_proxy} -t %{docker_tag} -f %{dockerfile} .
 %else if %{?oraclelinux} == 9
-docker build --pull --network=host --build-arg RPM=%{rpm_name}.rpm --build-arg https_proxy=${https_proxy} -t %{docker_tag} -f %{dockerfile} .
+docker build --pull=never --squash --network=host --build-arg RPM=%{rpm_name}.rpm --build-arg https_proxy=${https_proxy} -t %{docker_tag} -f %{dockerfile} .
 %endif
 docker save -o %{_name}.tar %{docker_tag}
 


### PR DESCRIPTION
Migrate the template to use the common base image strategy used by other core OCK components.  Refer to the issue for details.